### PR TITLE
feat(md) Introducing title and template frontmatter

### DIFF
--- a/md/bar.md
+++ b/md/bar.md
@@ -1,3 +1,8 @@
+---
+title: An apple a day keeps the doctor away!
+template: example/example-landing.twig
+---
+
 # Hello world
 
 ## This is a h2

--- a/md/foo.md
+++ b/md/foo.md
@@ -1,3 +1,7 @@
+---
+template: example/example-landing.twig
+title: Hello world!
+---
 # Hello world
 
 ## This is a h2

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,11 @@
         "uc.micro": "^1.0.5"
       }
     },
+    "markdown-it-front-matter": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/markdown-it-front-matter/-/markdown-it-front-matter-0.1.2.tgz",
+      "integrity": "sha1-5Qv1bnfmpPWsT/qJTU1FzNmJayA="
+    },
     "markdown-it-replace-link": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-replace-link/-/markdown-it-replace-link-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "html-minifier": "^4.0.0",
     "markdown-it": "^10.0.0",
+    "markdown-it-front-matter": "^0.1.2",
     "markdown-it-replace-link": "^1.0.1",
     "twig": "^1.14.0"
   }

--- a/templates/example/example-landing.twig
+++ b/templates/example/example-landing.twig
@@ -1,0 +1,11 @@
+{% extends "../main.twig" %}
+
+{% block after_content %}
+<footer>
+    <ol>
+        <li>Footer entry #1</li>
+        <li>Footer entry #2</li>
+        <li>Footer entry #3</li>
+    </ol>
+</footer>
+{% endblock %}

--- a/templates/main.twig
+++ b/templates/main.twig
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
-<html>
+<html lang="de">
     <head>
-        <title>{{ page_title }}</title>
+        <title>{{ title }}</title>
         <meta charset="utf-8"/>
     </head>
     <body>
-        {{ content }}
+        <main>
+            {{ content }}
+        </main>
+        {% block after_content %}{% endblock %}
     </body>
 </html>

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -2,5 +2,6 @@ const path = require("path");
 
 module.exports = {
   MARKDOWN_FOLDER: path.resolve("./md"),
-  DISTRIBUTION_FOLDER: path.resolve("./dist")
+  DISTRIBUTION_FOLDER: path.resolve("./dist"),
+  TEMPLATE_FOLDER: path.resolve("./templates")
 };

--- a/utils/frontmatter.js
+++ b/utils/frontmatter.js
@@ -1,0 +1,27 @@
+/**
+ * Returns frontmatter lines array based on given frontmatter string
+ * @param {string} frontmatterString 
+ * @returns {array}
+ */
+const frontmatterLines = frontmatterString => frontmatterString.split("\n");
+
+/**
+ * Based on given (multi-line) frontmatter string and tag, return the frontmatter line matching the tag.
+ * @param {string} frontmatterString 
+ * @param {string} tag 
+ * @returns {string|undefined}
+ */
+const findFrontmatterTag = (frontmatterString, tag) => {
+  return frontmatterLines(frontmatterString).find(
+    line => line.indexOf(tag) !== -1
+  );
+};
+
+/**
+ * Returns string based value of a frontmatter line.
+ * @param {string} frontmatterLine 
+ * @returns {string}
+ */
+const frontmatterValue = frontmatterLine => frontmatterLine.split(":")[1].trim();
+
+module.exports = { findFrontmatterTag, frontmatterLines, frontmatterValue };

--- a/utils/renderMDFile.js
+++ b/utils/renderMDFile.js
@@ -4,23 +4,63 @@ const fs = require("fs");
 const minify = require("html-minifier").minify;
 const Twig = require("twig");
 const isAbsoluteURL = require("./url").isAbsoluteURL;
+const frontmatterUtils = require("./frontmatter");
 const MarkdownIt = require("markdown-it"),
-  md = new MarkdownIt({
-    replaceLink: function(link) {
-      return isAbsoluteURL(link) || link.indexOf(".html") !== -1
-        ? link
-        : `${link}.html`;
-    }
-  }).use(require("markdown-it-replace-link"));
+  md = frontmatterCallback =>
+    new MarkdownIt({
+      replaceLink: function(link) {
+        return isAbsoluteURL(link) || link.indexOf(".html") !== -1
+          ? link
+          : `${link}.html`;
+      }
+    })
+      .use(require("markdown-it-replace-link"))
+      .use(require("markdown-it-front-matter"), frontmatterCallback);
 
 const MARKDOWN_FOLDER = require("./constants").MARKDOWN_FOLDER;
 const DISTRIBUTION_FOLDER = require("./constants").DISTRIBUTION_FOLDER;
+const TEMPLATE_FOLDER = require("./constants").TEMPLATE_FOLDER;
 
 module.exports = file => {
   const fileName = path.basename(file, ".md");
-  const twigTemplate = "./templates/main.twig";
+
+  // Set default template to render
+  let twigTemplate = "./templates/main.twig";
+
+  // Set default page title to the file name
+  let title = fileName;
+
   // Read in MD file synchronously.
   const mdString = fs.readFileSync(path.join(MARKDOWN_FOLDER, file), "utf8");
+  const htmlOutput = md(frontmatter => {
+    /* HANDLE TEMPLATE FRONTMATTER */
+    const templateFrontmatter = frontmatterUtils.findFrontmatterTag(
+      frontmatter,
+      "template"
+    );
+
+    if (templateFrontmatter) {
+      const templateName = frontmatterUtils.frontmatterValue(
+        templateFrontmatter
+      );
+
+      const targetTemplatePath = path.resolve(TEMPLATE_FOLDER, templateName);
+
+      if (fs.existsSync(targetTemplatePath)) {
+        twigTemplate = targetTemplatePath;
+      }
+    }
+
+    /* HANDLE TITLE FRONTMATTER */
+    const titleFrontmatter = frontmatterUtils.findFrontmatterTag(
+      frontmatter,
+      "title"
+    );
+
+    if (titleFrontmatter) {
+      title = frontmatterUtils.frontmatterValue(titleFrontmatter);
+    }
+  }).render(mdString);
 
   if (!fs.existsSync(DISTRIBUTION_FOLDER)) {
     fs.mkdirSync(DISTRIBUTION_FOLDER);
@@ -29,8 +69,8 @@ module.exports = file => {
   Twig.renderFile(
     twigTemplate,
     {
-      page_title: "foo",
-      content: md.render(mdString)
+      title,
+      content: htmlOutput
     },
     (err, html) => {
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
Introducing two frontmatter fields for the markdown files:

- template: Specifing a template (path) matching a file within the `templates` folder. Per default the `main.twig` file within the template root folder is used. E.g. foo/bar.twig to match <template_folder>/foo/bar.twig
- title: Specifing a page title. Per default the file name is used if nothing specified in the frontmatter

Fixes #1