### PR TITLE
feat(twig) - Provide the full frontmatter as meta(data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ The output files are saved to the `dist` directory.
 
 ## Twig Template Variables
 
-| Variable |         Description         |                             Example |
-| -------- | :-------------------------: | ----------------------------------: |
-| title    |      Title of the page      |       "Foo" (default: The filename) |
-| sites    |  Array of all build sites   | cf. [Site interface](./utils/md.ts) |
-| content  | Content of the page as HTML |        cf. `"<h1>Hello World</h1>"` |
-| base_url |  The base url of the page   |           cf. URL in env vars below |
+| Variable |                         Description                          |                                                      Example |
+| -------- | :----------------------------------------------------------: | -----------------------------------------------------------: |
+| title    |                      Title of the page                       |                                "Foo" (default: The filename) |
+| sites    |                   Array of all build sites                   |                          cf. [Site interface](./utils/md.ts) |
+| content  |                 Content of the page as HTML                  |                                 cf. `"<h1>Hello World</h1>"` |
+| base_url |                   The base url of the page                   |                                    cf. URL in env vars below |
+| meta     | All metadata provided via frontmatter for given site | cf. {title: 'foo', template: 'bar', author: 'Max Mustermann' |
 
 ## Environment Variables
 

--- a/md/meta-example.md
+++ b/md/meta-example.md
@@ -1,0 +1,9 @@
+---
+title: Foo
+template: example/example-meta.twig
+author: Max Mustermann
+foo: bar
+---
+# Metadata test
+
+This site should provide some further metadata to the Twig template.

--- a/templates/example/example-meta.twig
+++ b/templates/example/example-meta.twig
@@ -1,0 +1,5 @@
+{% extends "../main.twig" %}
+
+{% block after_content %}
+    {{dump(meta)}}
+{% endblock %}

--- a/utils/__tests__/frontmatter.test.ts
+++ b/utils/__tests__/frontmatter.test.ts
@@ -1,7 +1,8 @@
 const {
   frontmatterLines,
-  findFrontmatterTag,
-  frontmatterValue
+  frontmatterTag,
+  frontmatterValue,
+  findFrontmatterTag
 } = require("../frontmatter");
 
 describe("frontmatterLines", () => {
@@ -22,6 +23,14 @@ describe("frontmatterLines", () => {
         `
       ).length
     ).toBe(3);
+  });
+});
+
+describe("frontmatterTag", () => {
+  test("Simple tag", () => {
+    expect(frontmatterTag("title: An apple a day keeps the doctor away!")).toBe(
+      "title"
+    );
   });
 });
 

--- a/utils/frontmatter.ts
+++ b/utils/frontmatter.ts
@@ -1,10 +1,10 @@
 // https://stackoverflow.com/a/41975448/778340
-export { };
-  
+export {};
+
 /**
  * Returns frontmatter lines array based on given frontmatter string
  * @param {string} frontmatterString
- * @returns {array}
+ * @returns {array<string>}
  */
 const frontmatterLines = (frontmatterString: string): string[] =>
   frontmatterString.split("\n");
@@ -25,6 +25,14 @@ const findFrontmatterTag = (
 };
 
 /**
+ * Returns frontmatter tag for a given frontmatter line.
+ * @param {string} frontmatterLine 
+ * @returns {string}
+ */
+const frontmatterTag = (frontmatterLine: string): string =>
+  frontmatterLine.split(":")[0].trim();
+
+/**
  * Returns string based value of a frontmatter line.
  * @param {string} frontmatterLine
  * @returns {string}
@@ -32,4 +40,9 @@ const findFrontmatterTag = (
 const frontmatterValue = (frontmatterLine: string): string =>
   frontmatterLine.split(":")[1].trim();
 
-module.exports = { findFrontmatterTag, frontmatterLines, frontmatterValue };
+module.exports = {
+  findFrontmatterTag,
+  frontmatterLines,
+  frontmatterTag,
+  frontmatterValue
+};

--- a/utils/md.ts
+++ b/utils/md.ts
@@ -13,12 +13,18 @@ export interface File {
   rel: String;
 }
 
+export interface Meta {
+  title: String;
+  template: String;
+}
+
 export interface Site {
   title: String;
   template: String;
   html: String;
   file: File;
   url: URL;
+  meta: Meta;
 }
 
 const MarkdownIt = require("markdown-it"),
@@ -37,47 +43,29 @@ const getSiteObject = (absoluteFilePath: string): Site => {
   );
   const fileName = path.basename(absoluteFilePath, ".md");
 
-  // Set default template to render
-  let twigTemplate = "./templates/main.twig";
-
-  // Set default page title to the file name
-  let title = fileName;
+  // Meta-object
+  const DEFAULT_META = {
+    title: fileName, // Set default page title to the file name
+    template: "main.twig" // Set default template to render
+  };
+  let meta: Meta = DEFAULT_META;
 
   // Read in MD file synchronously.
   const mdString = fs.readFileSync(absoluteFilePath, "utf8");
   const htmlOutput = md((frontmatter: string): void => {
-    /* HANDLE TEMPLATE FRONTMATTER */
-    const templateFrontmatter = frontmatterUtils.findFrontmatterTag(
-      frontmatter,
-      "template"
-    );
-
-    if (templateFrontmatter) {
-      const templateName = frontmatterUtils.frontmatterValue(
-        templateFrontmatter
-      );
-
-      const targetTemplatePath = path.resolve(TEMPLATE_FOLDER, templateName);
-
-      if (fs.existsSync(targetTemplatePath)) {
-        twigTemplate = targetTemplatePath;
-      }
-    }
-
-    /* HANDLE TITLE FRONTMATTER */
-    const titleFrontmatter = frontmatterUtils.findFrontmatterTag(
-      frontmatter,
-      "title"
-    );
-
-    if (titleFrontmatter) {
-      title = frontmatterUtils.frontmatterValue(titleFrontmatter);
-    }
+    meta = frontmatterUtils
+      .frontmatterLines(frontmatter)
+      .reduce((acc: any, line: string): object => {
+        acc[
+          frontmatterUtils.frontmatterTag(line)
+        ] = frontmatterUtils.frontmatterValue(line);
+        return acc;
+      }, DEFAULT_META);
   }).render(mdString);
 
   return {
-    title,
-    template: twigTemplate,
+    title: meta.title,
+    template: path.resolve(TEMPLATE_FOLDER, meta.template),
     html: htmlOutput,
     file: {
       name: fileName,
@@ -86,7 +74,8 @@ const getSiteObject = (absoluteFilePath: string): Site => {
     },
     url: generateURL(
       path.relative(MARKDOWN_FOLDER, absoluteFilePath).replace(".md", "")
-    )
+    ),
+    meta
   };
 };
 

--- a/utils/renderMDFile.ts
+++ b/utils/renderMDFile.ts
@@ -16,12 +16,20 @@ module.exports = async (site: Site, sites: Site[]) => {
     fs.mkdirSync(DISTRIBUTION_FOLDER);
   }
 
+  // NOTE: Workaround of https://github.com/twigjs/twig.js/issues/509 to fail
+  // early in case of template does not exists, because renderFile is failing
+  // silently in that case.
+  if (!fs.existsSync(site.template)) {
+    throw new Error(`Template ${site.template} does not exist.`);
+  }
+  
   Twig.renderFile(
     site.template,
     {
       title: site.title,
       sites,
       content: site.html,
+      meta: site.meta,
       base_url: process.env.URL
     },
     (err: Error, html: string) => {


### PR DESCRIPTION
Provide the full frontmatter of a site as meta(data) to the Twig templates.

Fixes #19 