### PR TITLE
fix(pretty-urls): Limiting pretty URLs for trailing index URL segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ The output files are saved to the `dist` directory.
 
 ## CLI Options
 
-| Option   | Alias |                                                                                                  Description | Default |
-| -------- | :---: | -----------------------------------------------------------------------------------------------------------: | ------- |
-| --pretty |  --p  | Flag to indicate whether hosting can handle pretty URLs (e.g. `/hello/world` instead of `/hello/world.html`) | false   |
-| --clean  |  --c  |                           Flag to indicate whether distribution folder should be cleaned before every build. | false   |
+| Option  | Alias |                                                                        Description | Default |
+| ------- | :---: | ---------------------------------------------------------------------------------: | ------- |
+| --clean |  --c  | Flag to indicate whether distribution folder should be cleaned before every build. | false   |
 
 ## Environment Variables
 
-| Variable |   Description    |                      Example |
-| -------- | :--------------: | ---------------------------: |
-| URL      | URL of your page | `URL: https://www.google.de` |
+| Variable |                                                Description                                                 |                      Example |
+| -------- | :--------------------------------------------------------------------------------------------------------: | ---------------------------: |
+| URL      |                                              URL of your page                                              | `URL: https://www.google.de` |
+| PRETTY   | indicate whether hosting can handle pretty URLs (e.g. `/hello/world` instead of `/hello/world/index.html`) |               `PRETTY: true` |
 
 ## Configuration
 

--- a/utils/__mocks__/args.ts
+++ b/utils/__mocks__/args.ts
@@ -1,1 +1,1 @@
-module.exports = { _: [], p: true, pretty: true };
+module.exports = { _: [] };

--- a/utils/args.ts
+++ b/utils/args.ts
@@ -3,14 +3,8 @@ export {};
 const yargs = require("yargs");
 
 // Exports all CLI arguments
-module.exports = yargs
-  .option("clean", {
-    alias: "c",
-    describe: "Cleanup dist folder on startup",
-    type: "boolean",
-  })
-  .option("pretty", {
-    alias: "p",
-    describe: "Prettify URLs",
-    type: "boolean",
-  }).argv;
+module.exports = yargs.option("clean", {
+  alias: "c",
+  describe: "Cleanup dist folder on startup",
+  type: "boolean",
+}).argv;

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -19,12 +19,16 @@ const isAbsoluteURL = (url: string): Boolean => {
  * @returns {URL}
  */
 const generateURL = (link: string): URL => {
-  return new URL(
-    Boolean(args.pretty) || isAbsoluteURL(link) || link.indexOf(".html") !== -1
-      ? link.replace(/\/index$/g, "")
-      : `${link}.html`,
-    process.env.URL
-  );
+  if (isAbsoluteURL(link)) {
+    return new URL(link);
+  }
+
+  if (process.env.PRETTY === "true" && link.endsWith("index")) {
+    // In case we have support for pretty urls and link ends with index, we omit the last URL segment
+    return new URL(link.replace(/\/index$/g, ""), process.env.URL);
+  }
+
+  return new URL(`${link}.html`, process.env.URL);
 };
 
 module.exports = {

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -2,7 +2,6 @@ import { URL } from "url";
 
 // https://stackoverflow.com/a/41975448/778340
 export {};
-const args = require("./args");
 
 /**
  * Returns whether URL is absolute or not.


### PR DESCRIPTION
For the sake of more wide deployment support, we limit/restrict the
pretty URL support for trailing "index" URL segments only.

Before it was not restricted to this, means: "foo.com/mypage.html" was
transformed "foo.com/mypage". This case is taken out now and will stay
like "foo.com/mypage.html".

Fixes #224